### PR TITLE
NetStim no longer accepts MCellRan4 generator

### DIFF
--- a/README
+++ b/README
@@ -36,3 +36,4 @@ Changelog
          the same name. See https://github.com/neuronsimulator/nrn/pull/1992
 20230420 Do not assume a full definition of Section is visible, for
          compatibility with nrn#2027.
+20240226 Use noiseFromRandom123 for result identity between 8.2 and 9.0

--- a/nrntraub/hoc/parlib2.hoc
+++ b/nrntraub/hoc/parlib2.hoc
@@ -53,7 +53,8 @@ proc par_netstim_create() {local gid  localobj cell, syn, nc, ns, r
 		r.negexp(1)
 //		r.Isaac64(netstim_random_seedoffset + netstim_base_)
 		r.MCellRan4(netstim_random_seedoffset + 1000*netstim_base_)
-		ns.pp.noiseFromRandom(r)
+//		ns.pp.noiseFromRandom(r)
+                ns.pp.noiseFromRandom123(gid, netstim_base_, 0) // compatible back to 2016
 		netstim_randoms.append(r)
 	}
 	netstim_base_ += 1


### PR DESCRIPTION
Should produce same results (nrntraub part) for NEURON v7 onward.